### PR TITLE
menu_order_count() bugfix

### DIFF
--- a/admin/core/um-admin-dashboard.php
+++ b/admin/core/um-admin-dashboard.php
@@ -52,6 +52,10 @@ class UM_Admin_Dashboard {
 	public function menu_order_count() {
 		global $menu, $submenu;
 		
+		if( ! current_user_can( 'list_users' ) ){
+			return;
+		}
+		
 		$count = $this->get_pending_users_count();
 		
 		foreach( $menu as $key => $menu_item ) {


### PR DESCRIPTION
Patches issue where non-admin users visiting wp-admin resulted in the following messages: 
- Notice: Undefined index: users.php in .../wp-content/plugins/ultimate-member/admin/core/um-admin-dashboard.php on line 66
- Warning: Invalid argument supplied for foreach() in .../wp-content/plugins/ultimate-member/admin/core/um-admin-dashboard.php on line 66

(Only occurs if users do not have access to site user list)
